### PR TITLE
Fix "osclient-container: line 106: [: 5cc4616a6687: binary operator expected" notice.

### DIFF
--- a/osclient-container-install.sh
+++ b/osclient-container-install.sh
@@ -183,7 +183,7 @@ run_container(){
   # check if cloud tools docker image exists, if not pull latest. If a tag is
   # provided for a specific image version then pull that version
   IMAGEID=$(docker images --filter "reference=${DOCKERIMAGE}" --format "{{.ID}}")
-  if [ ! ${IMAGEID} ]; then
+  if [ ! "${IMAGEID}" ]; then
     docker pull ${DOCKERIMAGE}:latest
   elif [ ${DOCKER_TAG} ]; then
     docker pull ${DOCKERIMAGE}:${DOCKER_TAG}


### PR DESCRIPTION
To replicate:
```bash
$ docker pull catalystcloud/openstackclient-container:v0.89
$ docker pull catalystcloud/openstackclient-container:v0.98
$ osclient-container server list (or any other command)
```